### PR TITLE
use nearest neighbor resampling for gdal2tiles.py to avoid blue/green…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,4 +24,4 @@ dem_20m_RGB.tif: dem_20m_EPSG3857.tif
 
 # Need GDAL >3.2.0 for xyz options
 tiles/: dem_20m_RGB.tif
-	gdal2tiles.py --xyz --zoom=7-12 -s=EPSG:3857 --processes=8 $< $@ 
+	gdal2tiles.py --xyz --zoom=7-12 -r=near -s=EPSG:3857 --processes=8 $< $@


### PR DESCRIPTION
… mixing artifacts

I think this might solve the artifacts at the border; the tiles shouldn't resample at all, they should use the value of the nearest-neighbor pixel

I can't test it out right now though because my GDAL is too old :(